### PR TITLE
Exclude command-not-found from base image.

### DIFF
--- a/.github/workflows/dump.yml
+++ b/.github/workflows/dump.yml
@@ -343,6 +343,19 @@ jobs:
             ${{ tojson(steps.baseImage.outputs) }}
           ]
       shell: bash
+    - name: Dump gcc
+      id: gcc
+      run: |
+        ${{ env.CMD }} || ${{ env.CMD }}
+      env:
+        CMD: sudo tar --ignore-failed-read -C / -c --no-recursion /usr /usr/lib --recursion /usr/lib/gcc ${{ env.UP }}
+        UPLOAD_LAYER: 1
+        TAG: runner-gcc
+        LAYER_DIFF_IDS: |
+          [
+            ${{ tojson(steps.baseImage.outputs) }}
+          ]
+      shell: bash
     - name: Dump rust
       id: rust
       run: |
@@ -353,7 +366,8 @@ jobs:
         TAG: runner-rust
         LAYER_DIFF_IDS: |
           [
-            ${{ tojson(steps.baseImage.outputs) }}
+            ${{ tojson(steps.baseImage.outputs) }},
+            ${{ tojson(steps.gcc.outputs) }}
           ]
       shell: bash
     - name: Dump /usr/share/dotnet
@@ -429,19 +443,6 @@ jobs:
         CMD: sudo tar --ignore-failed-read -C / -c --no-recursion /usr /usr/lib --recursion /usr/lib/mono ${{ env.UP }}
         UPLOAD_LAYER: 1
         TAG: runner-mono
-        LAYER_DIFF_IDS: |
-          [
-            ${{ tojson(steps.baseImage.outputs) }}
-          ]
-      shell: bash
-    - name: Dump gcc
-      id: gcc
-      run: |
-        ${{ env.CMD }} || ${{ env.CMD }}
-      env:
-        CMD: sudo tar --ignore-failed-read -C / -c --no-recursion /usr /usr/lib --recursion /usr/lib/gcc ${{ env.UP }}
-        UPLOAD_LAYER: 1
-        TAG: runner-gcc
         LAYER_DIFF_IDS: |
           [
             ${{ tojson(steps.baseImage.outputs) }}

--- a/.github/workflows/dump.yml
+++ b/.github/workflows/dump.yml
@@ -300,7 +300,7 @@ jobs:
       run: |
         ${{ env.CMD }} || ${{ env.CMD }}
       env:
-        CMD: sudo tar --ignore-failed-read -C / -c --no-recursion /run /run/user /run/user/* --recursion "--exclude=$GITHUB_WORKSPACE" "--exclude=/proc/*" "--exclude=/dev/*" "--exclude=/run" "--exclude=/sys/*" "--exclude=/tmp/*" "--exclude=/opt/*" "--exclude=/var/cache/*" "--exclude=/var/snap" "--exclude=/var/run/*" "--exclude=/var/tmp/*" "--exclude=/var/crash/*" "--exclude=/var/lib/docker/*" "--exclude=/var/lib/apt/lists/*" "--exclude=/usr/local/*/*"  "--exclude=/mnt/*" "--exclude=/snap/*" "--exclude=/boot" "--exclude=/data" "--exclude=/boot" "--exclude=/imagegeneration/installers/*.tar.*" "--exclude=/home/runner/runners" "--exclude=/home/runner/work" "--exclude=/usr/share/dotnet" "--exclude=/etc/skel" "--exclude=/home/runner/.rustup" "--exclude=/home/runner/.cargo" "--exclude=/home/runner/.dotnet" "--exclude=/home/runneradmin" "--exclude=/usr/share/swift" "--exclude=/usr/share/miniconda" "--exclude=/usr/lib/google-cloud-sdk" "--exclude=/usr/lib/jvm" "--exclude=/usr/lib/mono" "--exclude=/usr/lib/gcc" "--exclude=/usr/lib/llvm-*" "--exclude=/usr/lib/firefox" "--exclude=/usr/lib/python3" "--exclude=/swapfile" / ${{ env.UP }}
+        CMD: sudo tar --ignore-failed-read -C / -c --no-recursion /run /run/user /run/user/* --recursion "--exclude=$GITHUB_WORKSPACE" "--exclude=/proc/*" "--exclude=/dev/*" "--exclude=/run" "--exclude=/sys/*" "--exclude=/tmp/*" "--exclude=/opt/*" "--exclude=/var/cache/*" "--exclude=/var/snap" "--exclude=/var/run/*" "--exclude=/var/tmp/*" "--exclude=/var/crash/*" "--exclude=/var/lib/docker/*" "--exclude=/var/lib/apt/lists/*" "--exclude=/usr/local/*/*"  "--exclude=/mnt/*" "--exclude=/snap/*" "--exclude=/boot" "--exclude=/data" "--exclude=/boot" "--exclude=/imagegeneration/installers/*.tar.*" "--exclude=/home/runner/runners" "--exclude=/home/runner/work" "--exclude=/usr/share/dotnet" "--exclude=/etc/skel" "--exclude=/home/runner/.rustup" "--exclude=/home/runner/.cargo" "--exclude=/home/runner/.dotnet" "--exclude=/home/runneradmin" "--exclude=/usr/share/swift" "--exclude=/usr/share/miniconda" "--exclude=/usr/lib/google-cloud-sdk" "--exclude=/usr/lib/jvm" "--exclude=/usr/lib/mono" "--exclude=/usr/lib/gcc" "--exclude=/usr/lib/llvm-*" "--exclude=/usr/lib/firefox" "--exclude=/usr/lib/python3" "--exclude=/etc/apt/apt.conf.d/50command-not-found" "--exclude=/usr/lib/cnf-update-db" "--exclude=/usr/lib/command-not-found" "--exclude=/etc/zsh_command_not_found" "--exclude=/var/lib/command-not-found" "--exclude=/swapfile" / ${{ env.UP }}
         UPLOAD_LAYER: 1
         TAG: runner-base
       shell: bash
@@ -479,7 +479,7 @@ jobs:
       run: |
         ${{ env.CMD }} || ${{ env.CMD }}
       env:
-        CMD: sudo tar --ignore-failed-read -C / -c --no-recursion /usr /usr/lib --recursion /usr/lib/python3 ${{ env.UP }}
+        CMD: sudo tar --ignore-failed-read -C / -c --no-recursion /usr /usr/lib /etc /etc/apt /etc/apt/apt.conf.d /var /var/lib /etc/apt/apt.conf.d/50command-not-found /usr/lib/cnf-update-db /usr/lib/command-not-found /etc/zsh_command_not_found --recursion /usr/lib/python3 /var/lib/command-not-found ${{ env.UP }}
         UPLOAD_LAYER: 1
         TAG: runner-python3
         LAYER_DIFF_IDS: |


### PR DESCRIPTION
On images without python3, `apt-get update` causes:
```Fetched 40.4 MB in 8s (5273 kB/s)
Traceback (most recent call last):
  File "/usr/lib/cnf-update-db", line 3, in <module>
    import apt_pkg
ModuleNotFoundError: No module named 'apt_pkg'
```.
This removes the python3 dependency on base image.